### PR TITLE
docs: add JSDoc comment for ExpressRouterAdapterConfig

### DIFF
--- a/src/ExpressRouterAdapter.ts
+++ b/src/ExpressRouterAdapter.ts
@@ -40,6 +40,11 @@ class PassThroughFormatter {
     }
 }
 
+/**
+ * ExpressRouterAdapterConfig provides configuration for route handling
+ * @property  BASE_PATH  The route's base path. Defaults to '/'.
+ * @property  TIMEOUT    The number of seconds till the route times outs. Defaults to 29 seconds
+ */
 export class ExpressRouterAdapterConfig {
     BASE_PATH: string = '/';
     TIMEOUT: string | number = '29s';


### PR DESCRIPTION
There wasn't a readily available document to view the defaults of types without running the typedoc generation utility on this library.  This patch exposes the necessary properties of the ExpressRouterAdapterConfig type and its defaults. This becomes useful to know on long running debugging sessions on APIs employing the library and need to override the defaults